### PR TITLE
Change output directory for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 .Rproj.user 
 .Rhistory 
 .RData 
-_publish.R 
-_book 
+_publish.R  
 _bookdown_files 
 rsconnect 
 /.Rbuildignore 

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -1,7 +1,7 @@
 book_filename: "ropensci-dev-guide"
 chapter_name: "Chapter "
 repo: https://github.com/ropenscilabs/dev_guide
-output_dir: _docs
+output_dir: _book
 rmd_files: ["index.Rmd", "pkg_building.Rmd",
            "pkg_ci.Rmd", "pkg_security.Rmd",
            "onboarding_intro.Rmd", "onboarding_policies.Rmd",

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -1,7 +1,7 @@
 book_filename: "ropensci-dev-guide"
 chapter_name: "Chapter "
 repo: https://github.com/ropenscilabs/dev_guide
-output_dir: docs
+output_dir: _docs
 rmd_files: ["index.Rmd", "pkg_building.Rmd",
            "pkg_ci.Rmd", "pkg_security.Rmd",
            "onboarding_intro.Rmd", "onboarding_policies.Rmd",


### PR DESCRIPTION
There was a mismatch between the directory that bookdown was generating the book in, and the directory that tic was trying to deploy.  Checking whether this works before merging, not sure if .gitignore will affect it.